### PR TITLE
Update importer scripts - Mar 4, 2026

### DIFF
--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Land Rover Egypt — AEM Bulk Import Entry Point
+ *
+ * Detects page template from URL, dispatches to the appropriate
+ * page transformer, and generates EDS-compliant document paths.
+ *
+ * Templates:
+ *   Homepage              — /en/
+ *   Vehicle Family (T2)   — /en/{family}/overview
+ *   Vehicle Model  (T3)   — /en/{family}/{year}/{model}/overview
+ */
+
+import homepageTransform from './page-transformers/homepage.js';
+import vehicleFamilyTransform from './page-transformers/vehicle-family-overview.js';
+import vehicleModelTransform from './page-transformers/vehicle-model-overview.js';
+import cleanupTransform from './transformers/landrover-cleanup.js';
+
+/* ------------------------------------------------------------------ */
+/*  Template detection                                                 */
+/* ------------------------------------------------------------------ */
+
+function detectTemplate(url) {
+  const path = new URL(url).pathname.replace(/\/$/, '');
+  const segments = path.split('/').filter(Boolean);
+
+  // Homepage: /en or /en/
+  if (segments.length <= 1) return 'homepage';
+
+  // T2 Vehicle Family: /en/{family}/overview  (3 segments)
+  if (segments.length === 3 && segments[2] === 'overview') {
+    return 'vehicle-family-overview';
+  }
+
+  // T3 Vehicle Model: /en/{family}/{year}/{model}/overview  (5 segments)
+  // Also handles longer paths like /en/range-rover/25my/range-rover/overview
+  if (segments.length >= 4 && segments[segments.length - 1] === 'overview') {
+    return 'vehicle-model-overview';
+  }
+
+  // Default to T3
+  return 'vehicle-model-overview';
+}
+
+/* ------------------------------------------------------------------ */
+/*  Export for AEM Bulk Import Tool                                     */
+/* ------------------------------------------------------------------ */
+
+export default {
+  /**
+   * Apply DOM operations to the provided document and return
+   * the root element to be then transformed to Markdown.
+   */
+  transformDOM({ document, url, html, params }) {
+    // 1. Run cleanup (beforeTransform)
+    cleanupTransform('beforeTransform', document.body, { document, url, html, params });
+
+    // 2. Detect template
+    const template = detectTemplate(url);
+
+    // 3. Get main content container
+    const main = document.querySelector('#rdx-render')
+      || document.querySelector('.blocks-list')
+      || document.querySelector('.jlr-content')
+      || document.body;
+
+    // 4. Dispatch to page transformer
+    let result;
+    switch (template) {
+      case 'homepage':
+        result = homepageTransform(main, document, url);
+        break;
+      case 'vehicle-family-overview':
+        result = vehicleFamilyTransform(main, document, url);
+        break;
+      case 'vehicle-model-overview':
+      default:
+        result = vehicleModelTransform(main, document, url);
+        break;
+    }
+
+    // 5. Run cleanup (afterTransform)
+    cleanupTransform('afterTransform', result, { document, url, html, params });
+
+    return result;
+  },
+
+  /**
+   * Return a path that describes the document being transformed.
+   */
+  generateDocumentPath({ document, url }) {
+    const u = new URL(url);
+    let path = u.pathname.replace(/\/$/, '') || '/index';
+    return WebImporter.FileUtils.sanitizePath(path);
+  },
+};

--- a/tools/importer/page-templates.json
+++ b/tools/importer/page-templates.json
@@ -3,36 +3,49 @@
     {
       "name": "Homepage",
       "urls": ["https://www.landrover-egypt.com/en/"],
-      "description": "Homepage with three vehicle family hero cards (Range Rover, Defender, Discovery) displayed as full-width cards with background images and ENTER CTA buttons.",
+      "description": "Homepage with three vehicle family hero cards (Range Rover, Defender, Discovery).",
       "blocks": [
-        {
-          "name": "cards",
-          "instances": [".jlr-house-of-brands-block"],
-          "section": "hero variant"
-        }
+        { "name": "cards", "instances": [".jlr-house-of-brands-block"], "section": "hero variant" }
       ]
     },
     {
       "name": "vehicle-family-overview",
-      "urls": ["https://www.landrover-egypt.com/en/defender/overview"],
-      "description": "Vehicle Family Overview page (T2) with hero, vehicle lineup cards, carousels, masonry columns sections, partnership and explore cards, and quick-action links bar.",
+      "urls": [
+        "https://www.landrover-egypt.com/en/defender/overview",
+        "https://www.landrover-egypt.com/en/discovery/overview"
+      ],
+      "description": "Vehicle Family Overview page (T2) with hero, vehicle lineup cards, masonry columns, story carousels, partnership/explore cards, and quicklinks at bottom.",
       "blocks": [
-        {
-          "name": "hero",
-          "instances": [".jlr-immersive-hero"]
-        },
-        {
-          "name": "cards",
-          "instances": [".jlr-content-blocks .jlr-grid--columns-4", ".jlr-content-blocks .jlr-grid--columns-2", ".jlr-content-blocks .jlr-grid--columns-3"]
-        },
-        {
-          "name": "carousel",
-          "instances": [".jlr-dual-frame-carousel", ".jlr-hero-slider-wrapper"]
-        },
-        {
-          "name": "columns",
-          "instances": [".jlr-masonry-block", ".ready-to-go-bar"]
-        }
+        { "name": "hero", "instances": [".jlr-immersive-hero"] },
+        { "name": "cards", "instances": [".jlr-content-blocks"] },
+        { "name": "carousel", "instances": [".jlr-dual-frame-carousel"] },
+        { "name": "hero-image-carousel", "instances": [".jlr-hero-slider-wrapper"] },
+        { "name": "columns", "instances": [".jlr-masonry-block"] },
+        { "name": "floating-quicklinks", "instances": [".ready-to-go-bar"] }
+      ]
+    },
+    {
+      "name": "vehicle-model-overview",
+      "urls": [
+        "https://www.landrover-egypt.com/en/defender/26my/defender-110/overview",
+        "https://www.landrover-egypt.com/en/defender/26my/defender-90/overview",
+        "https://www.landrover-egypt.com/en/defender/26my/defender-130/overview",
+        "https://www.landrover-egypt.com/en/discovery/26my/discovery/overview",
+        "https://www.landrover-egypt.com/en/discovery/26my/discovery-sport/overview",
+        "https://www.landrover-egypt.com/en/range-rover/25my/range-rover/overview",
+        "https://www.landrover-egypt.com/en/range-rover/25my/range-rover-sport/overview",
+        "https://www.landrover-egypt.com/en/range-rover/26my/range-rover-evoque/overview",
+        "https://www.landrover-egypt.com/en/range-rover/26my/range-rover-velar/overview"
+      ],
+      "description": "Vehicle Model Overview page (T3) with hero, floating quicklinks, quote banner, design/technology/performance sections, editions, build-and-order, keep-exploring carousel, disclaimers.",
+      "blocks": [
+        { "name": "hero", "instances": [".jlr-immersive-hero"] },
+        { "name": "floating-quicklinks", "instances": [".ready-to-go-bar"] },
+        { "name": "hero-image-carousel", "instances": [".jlr-hero-slider-wrapper"] },
+        { "name": "carousel", "instances": [".jlr-dual-frame-carousel"] },
+        { "name": "cards", "instances": [".jlr-content-blocks", ".jlr-collection-carousel"] },
+        { "name": "columns", "instances": [".jlr-masonry-block", ".jlr-hotspots-container", ".jlr-electrifying-power", ".jlr-tabbed-component"] },
+        { "name": "image-box", "instances": [".jlr-image-box"] }
       ]
     }
   ]

--- a/tools/importer/page-transformers/vehicle-family-overview.js
+++ b/tools/importer/page-transformers/vehicle-family-overview.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Vehicle Family Overview (T2) page transformer
+ *
+ * Handles 2 vehicle family pages:
+ *   /en/defender/overview
+ *   /en/discovery/overview
+ *
+ * T2 pages use the same block types as T3 (vehicle model overview):
+ *   Hero, Cards, Carousel, Hero Image Carousel, Columns (masonry),
+ *   Floating Quicklinks, snippets, disclaimers, Section Metadata, Metadata
+ *
+ * Since the DOM structure and block patterns are identical,
+ * this transformer delegates to the T3 transformer.
+ */
+
+import vehicleModelTransform from './vehicle-model-overview.js';
+
+export default function transform(main, document, url) {
+  return vehicleModelTransform(main, document, url);
+}

--- a/tools/importer/page-transformers/vehicle-model-overview.js
+++ b/tools/importer/page-transformers/vehicle-model-overview.js
@@ -1,0 +1,411 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Vehicle Model Overview (T3) page transformer
+ *
+ * Handles 9 vehicle model pages:
+ *   Defender 110/90/130, Discovery, Discovery Sport,
+ *   Range Rover, Range Rover Sport, Range Rover Evoque, Range Rover Velar
+ *
+ * Walks .rdx-render-block sections, identifies block types by CSS class,
+ * calls the appropriate parser, and builds the final DOM structure with
+ * section metadata and section separators.
+ */
+
+import heroParser from '../parsers/hero.js';
+import floatingQuicklinksParser from '../parsers/floating-quicklinks.js';
+import heroImageCarouselParser from '../parsers/hero-image-carousel.js';
+import imageBoxParser from '../parsers/image-box.js';
+import cardsParser from '../parsers/cards.js';
+import carouselParser from '../parsers/carousel.js';
+import columnsParser from '../parsers/columns.js';
+import hotspotsParser from '../parsers/hotspots.js';
+import electrifyingPowerParser from '../parsers/electrifying-power.js';
+import tabbedComponentParser from '../parsers/tabbed-component.js';
+import { createSectionMetadata, getStyleValue } from '../parsers/section-metadata.js';
+import { createMetadataBlock } from '../parsers/metadata.js';
+
+/* ------------------------------------------------------------------ */
+/*  Block type identification                                          */
+/* ------------------------------------------------------------------ */
+
+function getBlockType(section) {
+  if (!section) return 'unknown';
+  const cls = section.className || '';
+
+  // Order matters: more specific checks first
+  if (cls.includes('jlr-immersive-hero')) return 'hero';
+  if (cls.includes('ready-to-go-bar')) return 'floating-quicklinks';
+  if (cls.includes('jlr-in-page-navigation')) return 'remove';
+  if (cls.includes('jlr-html-box')) return 'remove';
+  if (cls.includes('jlr-hero-slider-wrapper')) return 'hero-image-carousel';
+  if (cls.includes('jlr-dual-frame-carousel')) return 'carousel';
+  if (cls.includes('jlr-hotspots-container')) return 'hotspots';
+  if (cls.includes('jlr-electrifying-power')) return 'electrifying-power';
+  if (cls.includes('jlr-masonry-block')) return 'columns-masonry';
+  if (cls.includes('jlr-collection-carousel')) return 'cards-collection';
+
+  // Check for nested elements
+  if (section.querySelector('.jlr-image-box-holder') || section.querySelector('.jlr-image-box')) return 'image-box';
+  if (section.querySelector('.jlr-content-blocks')) return 'cards';
+  if (section.querySelector('.jlr-tabbed-component')) return 'tabbed-component';
+
+  // Snippet sections (headings, disclaimers, default content)
+  const snippet = section.querySelector('.jlr-snippet');
+  if (snippet) {
+    if (snippet.classList.contains('jlr-snippet--disclaimer') || section.querySelector('.jlr-snippet--disclaimer')) {
+      return 'disclaimer';
+    }
+    return 'snippet';
+  }
+
+  // Tab navigation (standalone .jlr-tabs without tabbed-component)
+  if (cls.includes('jlr-tabs') || section.querySelector('.jlr-tabs__navigation')) return 'tab-nav';
+
+  return 'unknown';
+}
+
+/**
+ * Get theme class from a section element
+ */
+function getTheme(section) {
+  const cls = section.className || '';
+  if (cls.includes('jlr-section--dark-theme')) return 'jlr-section--dark-theme';
+  if (cls.includes('jlr-section--light-theme')) return 'jlr-section--light-theme';
+  if (cls.includes('jlr-section--grey-theme')) return 'jlr-section--grey-theme';
+  return null; // white/default = no section metadata
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helper: call a parser safely                                       */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Wraps a section in a temporary parent, calls the parser,
+ * and returns the resulting element(s).
+ */
+function callParser(parser, section, document) {
+  const wrapper = document.createElement('div');
+  wrapper.appendChild(section);
+  parser(section, { document });
+  // Parser replaced section with block via replaceWith
+  // Return all children of wrapper (usually just the block)
+  return Array.from(wrapper.childNodes);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helper: create elements                                            */
+/* ------------------------------------------------------------------ */
+
+function createHr(document) {
+  return document.createElement('hr');
+}
+
+function createHeading(document, text, level) {
+  const h = document.createElement(`h${level}`);
+  h.textContent = text;
+  return h;
+}
+
+function createParagraph(document, text) {
+  const p = document.createElement('p');
+  p.textContent = text;
+  return p;
+}
+
+function createLink(document, href, text) {
+  const a = document.createElement('a');
+  a.href = href;
+  a.textContent = text;
+  return a;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helper: extract snippet content as default content                 */
+/* ------------------------------------------------------------------ */
+
+function extractSnippetContent(section, document) {
+  const elements = [];
+
+  const snippet = section.querySelector('.jlr-snippet');
+  if (!snippet) return elements;
+
+  // Extract heading
+  const heading = snippet.querySelector('.jlr-snippet__heading');
+  if (heading) {
+    elements.push(createHeading(document, heading.textContent.trim(), 2));
+  }
+
+  // Extract paragraph
+  const paragraph = snippet.querySelector('.jlr-snippet__paragraph');
+  if (paragraph) {
+    elements.push(createParagraph(document, paragraph.textContent.trim()));
+  }
+
+  // Extract CTA buttons
+  const buttons = Array.from(snippet.querySelectorAll('.jlr-snippet__button, .jlr-snippet__container-buttons a'));
+  buttons.forEach((btn) => {
+    elements.push(createLink(document, btn.getAttribute('href'), btn.textContent.trim()));
+  });
+
+  return elements;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helper: extract disclaimer content                                 */
+/* ------------------------------------------------------------------ */
+
+function extractDisclaimerContent(section, document) {
+  const elements = [];
+
+  const disclaimer = section.querySelector('.jlr-snippet--disclaimer');
+  if (!disclaimer) return elements;
+
+  const paragraphs = Array.from(disclaimer.querySelectorAll('.jlr-paragraph p, .jlr-paragraph'));
+  paragraphs.forEach((p) => {
+    const text = p.textContent.trim();
+    if (text) {
+      elements.push(createParagraph(document, text));
+    }
+  });
+
+  // If no paragraphs found, try to get text directly
+  if (elements.length === 0) {
+    const text = disclaimer.textContent.trim();
+    if (text) {
+      elements.push(createParagraph(document, text));
+    }
+  }
+
+  return elements;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helper: parse collection carousel as Cards                         */
+/* ------------------------------------------------------------------ */
+
+function parseCollectionCarousel(section, document) {
+  const cells = [];
+
+  const slides = Array.from(
+    section.querySelectorAll('.jlr-collection-carousel__slide')
+  ).filter((s) => !s.classList.contains('swiper-slide-duplicate'));
+
+  slides.forEach((slide) => {
+    const img = slide.querySelector('.jlr-collection-card__image img') || slide.querySelector('img');
+    const title = slide.querySelector('.jlr-collection-card__description-title');
+    const desc = slide.querySelector('.jlr-collection-card__description-text');
+
+    const imageCell = [];
+    if (img) {
+      const imgEl = document.createElement('img');
+      imgEl.src = img.getAttribute('src');
+      imgEl.alt = img.getAttribute('alt') || '';
+      imageCell.push(imgEl);
+    }
+
+    const textCell = [];
+    if (title) {
+      const strong = document.createElement('strong');
+      strong.textContent = title.textContent.trim();
+      textCell.push(strong);
+    }
+    if (desc) {
+      textCell.push(desc.textContent.trim());
+    }
+
+    cells.push([imageCell, textCell]);
+  });
+
+  return WebImporter.Blocks.createBlock(document, { name: 'Cards', cells });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main transformer                                                   */
+/* ------------------------------------------------------------------ */
+
+export default function transform(main, document, url) {
+  const output = document.createElement('div');
+
+  // Find all rdx-render-block containers
+  const renderBlocks = Array.from(main.querySelectorAll('.rdx-render-block'));
+
+  let pendingSnippet = null; // Buffered snippet heading for next section
+  let hotspotImages = [];     // Accumulated hotspot images for pairing
+
+  for (let i = 0; i < renderBlocks.length; i++) {
+    const renderBlock = renderBlocks[i];
+
+    // Skip inactive tab content
+    if (renderBlock.classList.contains('rdx-render-block--tab')
+      && !renderBlock.classList.contains('rdx-render-block--tab-current')) {
+      continue;
+    }
+
+    const section = renderBlock.querySelector(':scope > section')
+      || renderBlock.querySelector('section');
+    if (!section) continue;
+
+    const blockType = getBlockType(section);
+    const theme = getTheme(section);
+
+    // Skip elements that should be removed
+    if (blockType === 'remove' || blockType === 'tab-nav') continue;
+
+    // Handle snippets (section headings) — buffer them
+    if (blockType === 'snippet') {
+      pendingSnippet = extractSnippetContent(section, document);
+      continue;
+    }
+
+    // Flush hotspot images if the current block isn't a hotspot
+    if (blockType !== 'hotspots' && hotspotImages.length > 0) {
+      // Create a Columns block from paired hotspot images
+      // Ground truth: | ![Exterior](url) | ![Interior](url) |  (one row, two cells)
+      const hotspotBlock = WebImporter.Blocks.createBlock(document, {
+        name: 'Columns',
+        cells: [hotspotImages.map((img) => [img])],
+      });
+      output.appendChild(hotspotBlock);
+      output.appendChild(createHr(document));
+      hotspotImages = [];
+    }
+
+    // Add pending snippet heading before the current block
+    if (pendingSnippet) {
+      // If previous section ended with <hr>, the snippet is part of the new section
+      pendingSnippet.forEach((el) => output.appendChild(el));
+      pendingSnippet = null;
+    }
+
+    // Process the block based on type
+    let blockElements = [];
+
+    switch (blockType) {
+      case 'hero': {
+        const nodes = callParser(heroParser, section, document);
+        blockElements = nodes;
+        break;
+      }
+
+      case 'floating-quicklinks': {
+        const nodes = callParser(floatingQuicklinksParser, section, document);
+        blockElements = nodes;
+        break;
+      }
+
+      case 'image-box': {
+        const nodes = callParser(imageBoxParser, section, document);
+        blockElements = nodes;
+        break;
+      }
+
+      case 'cards': {
+        const nodes = callParser(cardsParser, section, document);
+        blockElements = nodes;
+        break;
+      }
+
+      case 'cards-collection': {
+        const block = parseCollectionCarousel(section, document);
+        blockElements = [block];
+        break;
+      }
+
+      case 'hero-image-carousel': {
+        const nodes = callParser(heroImageCarouselParser, section, document);
+        blockElements = nodes;
+        break;
+      }
+
+      case 'carousel': {
+        const nodes = callParser(carouselParser, section, document);
+        blockElements = nodes;
+        break;
+      }
+
+      case 'columns-masonry': {
+        const nodes = callParser(columnsParser, section, document);
+        blockElements = nodes;
+        break;
+      }
+
+      case 'hotspots': {
+        // Accumulate hotspot images for pairing
+        const img = section.querySelector('.jlr-hotspots-wrapper img')
+          || section.querySelector('img');
+        if (img) {
+          const imgEl = document.createElement('img');
+          imgEl.src = img.getAttribute('src');
+          imgEl.alt = img.getAttribute('alt') || '';
+          hotspotImages.push(imgEl);
+        }
+        continue; // Don't add to output yet
+      }
+
+      case 'electrifying-power': {
+        const nodes = callParser(electrifyingPowerParser, section, document);
+        blockElements = nodes;
+        break;
+      }
+
+      case 'tabbed-component': {
+        const nodes = callParser(tabbedComponentParser, section, document);
+        blockElements = nodes;
+        break;
+      }
+
+      case 'disclaimer': {
+        const disclaimerElements = extractDisclaimerContent(section, document);
+        disclaimerElements.forEach((el) => output.appendChild(el));
+
+        // Add Section Metadata: disclaimer
+        const disclaimerMeta = createSectionMetadata(document, 'jlr-section--grey-theme');
+        if (disclaimerMeta) {
+          output.appendChild(disclaimerMeta);
+        }
+        output.appendChild(createHr(document));
+        continue;
+      }
+
+      default:
+        continue;
+    }
+
+    // Append block elements to output
+    blockElements.forEach((el) => output.appendChild(el));
+
+    // Add Section Metadata if theme is not white/default
+    if (theme) {
+      const style = getStyleValue(theme);
+      if (style) {
+        const sectionMeta = createSectionMetadata(document, theme);
+        if (sectionMeta) {
+          output.appendChild(sectionMeta);
+        }
+      }
+    }
+
+    // Add section separator
+    output.appendChild(createHr(document));
+  }
+
+  // Flush any remaining hotspot images
+  if (hotspotImages.length > 0) {
+    const hotspotBlock = WebImporter.Blocks.createBlock(document, {
+      name: 'Columns',
+      cells: [hotspotImages.map((img) => [img])],
+    });
+    output.appendChild(hotspotBlock);
+    output.appendChild(createHr(document));
+  }
+
+  // Append page Metadata block
+  const metadataBlock = createMetadataBlock(document);
+  if (metadataBlock) {
+    output.appendChild(metadataBlock);
+  }
+
+  return output;
+}

--- a/tools/importer/parsers/carousel.js
+++ b/tools/importer/parsers/carousel.js
@@ -20,13 +20,7 @@
  *   </div>
  * </section>
  *
- * Pattern 2 - Hero Slider (.jlr-hero-slider-wrapper):
- * <div class="jlr-hero-slider-wrapper">
- *   <div class="jlr-hero-slider__item">
- *     <img class="jlr-hero-slider__bg-image">
- *     <h2>heading</h2><p>description</p><a>CTA</a>
- *   </div>
- * </div>
+ * Note: Hero Slider (.jlr-hero-slider-wrapper) is handled by hero-image-carousel.js
  *
  * Generated: 2026-02-27
  */
@@ -77,55 +71,6 @@ export default function parse(element, { document }) {
       }
       if (text) {
         textCell.push(text.textContent.trim());
-      }
-      if (cta) {
-        const a = document.createElement('a');
-        a.href = cta.getAttribute('href');
-        a.textContent = cta.textContent.trim();
-        textCell.push(a);
-      }
-
-      cells.push([imageCell, textCell]);
-    });
-  } else {
-    // Pattern 2: Hero slider carousel
-    // VALIDATED: .jlr-hero-slider__item inside .jlr-hero-slider-wrapper
-    const heroSlides = Array.from(
-      element.querySelectorAll('.jlr-hero-slider__item, .swiper-slide')
-    );
-
-    heroSlides.forEach((slide) => {
-      // Extract background image
-      const img = slide.querySelector('.jlr-hero-slider__bg-image') ||
-                  slide.querySelector('img');
-
-      // Extract heading
-      const heading = slide.querySelector('h2, h1, h3');
-
-      // Extract description
-      const desc = slide.querySelector('.jlr-hero-slider__copy__paragraph') ||
-                   slide.querySelector('p');
-
-      // Extract CTA
-      const cta = slide.querySelector('a.jlr-button') ||
-                  slide.querySelector('a');
-
-      const imageCell = [];
-      if (img) {
-        const imgEl = document.createElement('img');
-        imgEl.src = img.getAttribute('src');
-        imgEl.alt = img.getAttribute('alt') || '';
-        imageCell.push(imgEl);
-      }
-
-      const textCell = [];
-      if (heading) {
-        const h2 = document.createElement('h2');
-        h2.textContent = heading.textContent.trim();
-        textCell.push(h2);
-      }
-      if (desc) {
-        textCell.push(desc.textContent.trim());
       }
       if (cta) {
         const a = document.createElement('a');

--- a/tools/importer/parsers/columns.js
+++ b/tools/importer/parsers/columns.js
@@ -23,8 +23,7 @@
  * </section>
  * Reversed variant: .jlr-grid--columns-3-reversed (images first, text second)
  *
- * Pattern 2 - Ready-to-go bar (.ready-to-go-bar):
- * Horizontal row of 4 quick-action links
+ * Note: Ready-to-go bar (.ready-to-go-bar) is handled by floating-quicklinks.js
  *
  * Generated: 2026-02-27
  */
@@ -99,19 +98,6 @@ export default function parse(element, { document }) {
       cells.push([imageCell, textCell]);
     } else {
       cells.push([textCell, imageCell]);
-    }
-  } else {
-    // Pattern 2: Ready-to-go bar or generic columns
-    // Extract all links as individual columns
-    const links = Array.from(element.querySelectorAll('a'));
-    if (links.length > 0) {
-      const row = links.map((link) => {
-        const a = document.createElement('a');
-        a.href = link.getAttribute('href');
-        a.textContent = link.textContent.trim();
-        return [a];
-      });
-      cells.push(row);
     }
   }
 

--- a/tools/importer/parsers/electrifying-power.js
+++ b/tools/importer/parsers/electrifying-power.js
@@ -1,0 +1,128 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Parser for electrifying-power → Columns block with formatted specs
+ *
+ * Source: .jlr-electrifying-power
+ * Base Block: Columns
+ *
+ * Block Structure (from markdown example):
+ * | **Columns** | |
+ * | --- | --- |
+ * | ## HEADING Description SPEC_LABEL: VALUE / SPEC_LABEL: VALUE [CTA](url) | ![img](url) |
+ * OR reversed:
+ * | ![img](url) | ## HEADING Description SPEC_LABEL: VALUE / SPEC_LABEL: VALUE |
+ *
+ * Source HTML Pattern:
+ * <section class="jlr-electrifying-power jlr-section">
+ *   <div class="jlr-grid--columns-3">
+ *     <div class="jlr-electrifying-power__copy">
+ *       <div class="jlr-electrifying-power__items">
+ *         <div class="jlr-electrifying-power__item">
+ *           <h4 class="__tagline">0-100 KM/H</h4>
+ *           <h5 class="__title"><span>4,0</span>SEC</h5>
+ *         </div>
+ *         ...
+ *       </div>
+ *       <div class="jlr-column-template">
+ *         <h2>DEFENDER OCTA</h2>
+ *         <div class="jlr-column-template__paragraph">Description</div>
+ *         <a href="...">CTA</a>
+ *       </div>
+ *     </div>
+ *     <picture class="jlr-electrifying-power__image"><img></picture>
+ *   </div>
+ * </section>
+ *
+ * Generated: 2026-03-04
+ */
+export default function parse(element, { document }) {
+  const cells = [];
+
+  // Extract heading
+  const heading = element.querySelector('.jlr-column-template__heading')
+    || element.querySelector('.jlr-electrifying-power__copy h2');
+
+  // Extract description
+  const desc = element.querySelector('.jlr-column-template__paragraph');
+
+  // Extract spec items
+  const specItems = Array.from(element.querySelectorAll('.jlr-electrifying-power__item'));
+  const specs = specItems.map((item) => {
+    const tagline = item.querySelector('.jlr-electrifying-power__item__tagline');
+    const title = item.querySelector('.jlr-electrifying-power__item__title');
+    if (tagline && title) {
+      const label = tagline.textContent.trim();
+      const value = title.textContent.trim().replace(/\s+/g, ' ');
+      return `${label}: ${value}`;
+    }
+    return null;
+  }).filter(Boolean);
+
+  // Extract CTAs
+  const ctaLinks = Array.from(element.querySelectorAll('.jlr-column-template__link a, .jlr-electrifying-power__copy a.jlr-cta, .jlr-electrifying-power__copy a.jlr-button'));
+
+  // Extract image
+  const img = element.querySelector('.jlr-electrifying-power__image img')
+    || element.querySelector('picture img');
+
+  // Build text cell
+  const textCell = [];
+  if (heading) {
+    const h2 = document.createElement('h2');
+    h2.textContent = heading.textContent.trim();
+    textCell.push(h2);
+  }
+
+  // Combine description and specs into one text block
+  let textContent = '';
+  if (desc) {
+    // Get clean text, strip footnote markers
+    textContent = desc.textContent.trim().replace(/<[^>]+>/g, '');
+  }
+  if (specs.length > 0) {
+    const specLine = specs.join(' / ');
+    textContent = textContent ? `${textContent} ${specLine}` : specLine;
+  }
+  if (textContent) {
+    textCell.push(textContent);
+  }
+
+  ctaLinks.forEach((link) => {
+    const a = document.createElement('a');
+    a.href = link.getAttribute('href');
+    a.textContent = link.textContent.trim();
+    textCell.push(a);
+  });
+
+  // Build image cell
+  const imageCell = [];
+  if (img) {
+    const imgEl = document.createElement('img');
+    imgEl.src = img.getAttribute('src');
+    imgEl.alt = img.getAttribute('alt') || '';
+    imageCell.push(imgEl);
+  }
+
+  // Determine layout order: check if image comes before text in DOM
+  const copyEl = element.querySelector('.jlr-electrifying-power__copy');
+  const imageEl = element.querySelector('.jlr-electrifying-power__image');
+
+  let textFirst = true;
+  if (copyEl && imageEl) {
+    // Compare DOM positions - if image appears before copy, it's image-first
+    const position = copyEl.compareDocumentPosition(imageEl);
+    // eslint-disable-next-line no-bitwise
+    textFirst = !!(position & Node.DOCUMENT_POSITION_FOLLOWING);
+  }
+
+  if (textFirst) {
+    cells.push([textCell, imageCell]);
+  } else {
+    cells.push([imageCell, textCell]);
+  }
+
+  const block = WebImporter.Blocks.createBlock(document, { name: 'Columns', cells });
+  element.replaceWith(block);
+}

--- a/tools/importer/parsers/floating-quicklinks.js
+++ b/tools/importer/parsers/floating-quicklinks.js
@@ -1,0 +1,65 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Parser for Floating Quicklinks block
+ *
+ * Source: .ready-to-go-bar
+ * Base Block: Floating Quicklinks
+ *
+ * Block Structure (from markdown example):
+ * | **Floating Quicklinks** | |
+ * | --- | --- |
+ * | :configure: | [BUILD YOUR OWN](url) |
+ * | :steering-wheel: | [BOOK A TEST DRIVE](url) |
+ * | :calculator: | [REQUEST A CALLBACK](url) |
+ * | :envelope: | [FIND A RETAILER](url) |
+ *
+ * Source HTML Pattern:
+ * <section class="ready-to-go-bar jlr-section">
+ *   <div class="jlr-grid__wrapper">
+ *     <div class="jlr-grid jlr-grid--columns-4">
+ *       <a href="..." class="ready-to-go-bar__item">
+ *         <i class="ready-to-go-bar__icon jlr-icon icon-ignite-configure">
+ *         <div class="ready-to-go-bar__cta"><span>Build your own</span></div>
+ *       </a>
+ *       ...
+ *     </div>
+ *   </div>
+ * </section>
+ *
+ * Generated: 2026-03-04
+ */
+import { getIconName } from '../utils/icon-map.js';
+
+export default function parse(element, { document }) {
+  const cells = [];
+
+  // Extract quicklink items
+  const items = Array.from(element.querySelectorAll('.ready-to-go-bar__item'));
+
+  items.forEach((item, index) => {
+    const href = item.getAttribute('href');
+
+    // Extract CTA text from the cta span
+    const ctaText = item.querySelector('.jlr-cta__text span, .jlr-cta__text, .ready-to-go-bar__cta span');
+    const linkText = ctaText ? ctaText.textContent.trim() : '';
+
+    // Determine icon from the icon element's class
+    const iconEl = item.querySelector('.ready-to-go-bar__icon');
+    const iconName = getIconName(iconEl, index);
+
+    // Build icon cell
+    const iconCell = `:${iconName}:`;
+
+    // Build link cell
+    const link = document.createElement('a');
+    link.href = href;
+    link.textContent = linkText.toUpperCase();
+
+    cells.push([iconCell, [link]]);
+  });
+
+  const block = WebImporter.Blocks.createBlock(document, { name: 'Floating Quicklinks', cells });
+  element.replaceWith(block);
+}

--- a/tools/importer/parsers/hero-image-carousel.js
+++ b/tools/importer/parsers/hero-image-carousel.js
@@ -1,0 +1,89 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Parser for Hero Image Carousel block
+ *
+ * Source: .jlr-hero-slider-wrapper
+ * Base Block: Hero Image Carousel
+ *
+ * Block Structure (from markdown example):
+ * | **Hero Image Carousel** | |
+ * | --- | --- |
+ * | ![alt](image-url) | ## HEADING Description text |
+ * | ![alt](image-url) | ## HEADING Description text |
+ *
+ * Source HTML Pattern:
+ * <section class="jlr-hero-slider-wrapper jlr-section">
+ *   <div class="jlr-hero-carousel-core">
+ *     <swiper-container>
+ *       <div class="swiper-slide jlr-slide">
+ *         <div class="jlr-hero-carousel-slide-core">
+ *           <div class="jlr-hero-carousel-slide-core__media-box">
+ *             <picture><img src="..." alt="..."></picture>
+ *           </div>
+ *           <div class="jlr-hero-slider-banner">
+ *             <div class="jlr-hero-slider-banner__copy">
+ *               <h3>heading</h3>
+ *               <div class="jlr-paragraph">description</div>
+ *             </div>
+ *           </div>
+ *         </div>
+ *       </div>
+ *     </swiper-container>
+ *   </div>
+ * </section>
+ *
+ * Generated: 2026-03-04
+ */
+export default function parse(element, { document }) {
+  const cells = [];
+
+  // Get all slides, filtering out swiper duplicates
+  const slides = Array.from(
+    element.querySelectorAll('.swiper-slide.jlr-slide')
+  ).filter((slide) => !slide.classList.contains('swiper-slide-duplicate'));
+
+  slides.forEach((slide) => {
+    // Extract image
+    const img = slide.querySelector('.jlr-hero-carousel-slide-core__media-box img')
+      || slide.querySelector('.jlr-hero-slider__bg-image')
+      || slide.querySelector('img');
+
+    // Extract heading from banner
+    const heading = slide.querySelector('.jlr-hero-slider-banner__copy h3')
+      || slide.querySelector('.jlr-hero-slider-banner__copy h2')
+      || slide.querySelector('.jlr-hero-slider-banner h3, .jlr-hero-slider-banner h2');
+
+    // Extract description
+    const desc = slide.querySelector('.jlr-hero-slider-banner__copy .jlr-paragraph')
+      || slide.querySelector('.jlr-hero-slider-banner__copy div[class*="paragraph"]');
+
+    // Build image cell
+    const imageCell = [];
+    if (img) {
+      const imgEl = document.createElement('img');
+      imgEl.src = img.getAttribute('src');
+      imgEl.alt = img.getAttribute('alt') || '';
+      imageCell.push(imgEl);
+    }
+
+    // Build text cell
+    const textCell = [];
+    if (heading) {
+      const h2 = document.createElement('h2');
+      h2.textContent = heading.textContent.trim();
+      textCell.push(h2);
+    }
+    if (desc) {
+      textCell.push(desc.textContent.trim());
+    }
+
+    if (imageCell.length > 0 || textCell.length > 0) {
+      cells.push([imageCell, textCell]);
+    }
+  });
+
+  const block = WebImporter.Blocks.createBlock(document, { name: 'Hero Image Carousel', cells });
+  element.replaceWith(block);
+}

--- a/tools/importer/parsers/hero.js
+++ b/tools/importer/parsers/hero.js
@@ -37,10 +37,9 @@ export default function parse(element, { document }) {
   // VALIDATED: div class="jlr-immersive-hero__content__paragraph"
   const subtitle = element.querySelector('.jlr-immersive-hero__content__paragraph');
 
-  // Extract CTA links
-  // VALIDATED: a.jlr-button inside .jlr-immersive-hero__content__buttons-holder
+  // Extract CTA links (primary buttons and anchor buttons)
   const ctaLinks = Array.from(
-    element.querySelectorAll('.jlr-immersive-hero__content__buttons-holder a.jlr-button')
+    element.querySelectorAll('.jlr-immersive-hero__content__buttons-holder a.jlr-button, .jlr-immersive-hero__content__buttons-holder a.jlr-immersive-hero__content__anchor-button')
   );
 
   // Build cells matching Hero block markdown structure
@@ -58,7 +57,7 @@ export default function parse(element, { document }) {
     cells.push([h1]);
   }
 
-  // Row 3: Subtitle + CTAs
+  // Row 3: Subtitle + CTAs + optional video link
   const contentCell = [];
   if (subtitle) {
     contentCell.push(subtitle.textContent.trim());
@@ -69,6 +68,18 @@ export default function parse(element, { document }) {
     a.textContent = link.textContent.trim();
     contentCell.push(a);
   });
+
+  // Extract video if present (desktop source preferred)
+  const videoSource = element.querySelector('.jlr-immersive-hero__video video source[src]')
+    || element.querySelector('.jlr-native-video-frame video source[src]')
+    || element.querySelector('video source[src]');
+  if (videoSource) {
+    const videoLink = document.createElement('a');
+    videoLink.href = videoSource.getAttribute('src');
+    videoLink.textContent = 'video';
+    contentCell.push(videoLink);
+  }
+
   if (contentCell.length > 0) {
     cells.push(contentCell);
   }

--- a/tools/importer/parsers/hotspots.js
+++ b/tools/importer/parsers/hotspots.js
@@ -1,0 +1,51 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Parser for hotspots container → extracts main image
+ *
+ * Source: .jlr-hotspots-container
+ * Output: Returns the main image element for the page transformer to pair
+ *
+ * The page transformer collects images from consecutive hotspot sections
+ * and pairs them into a single Columns block (exterior | interior).
+ *
+ * Markdown output example (after pairing by page transformer):
+ * | **Columns** | |
+ * | --- | --- |
+ * | ![Exterior](img1) | ![Interior](img2) |
+ *
+ * Source HTML Pattern:
+ * <section class="jlr-hotspots-container jlr-section">
+ *   <div class="jlr-hotspots-container__box">
+ *     <div class="jlr-hotspots-container__columns">
+ *       <div class="jlr-hotspots-wrapper">
+ *         <picture><img src="..." alt="..."></picture>
+ *         <div class="jlr-hotspots-wrapper__item">...</div>
+ *       </div>
+ *     </div>
+ *   </div>
+ * </section>
+ *
+ * Generated: 2026-03-04
+ */
+export default function parse(element, { document }) {
+  // Extract the main hotspot image (first image in the wrapper)
+  const img = element.querySelector('.jlr-hotspots-wrapper img')
+    || element.querySelector('.jlr-hotspots-container__columns img')
+    || element.querySelector('img');
+
+  if (img) {
+    const imgEl = document.createElement('img');
+    imgEl.src = img.getAttribute('src');
+    imgEl.alt = img.getAttribute('alt') || '';
+    // Mark this element for the page transformer to collect
+    imgEl.setAttribute('data-hotspot-image', 'true');
+    element.replaceWith(imgEl);
+    return imgEl;
+  }
+
+  // Remove if no image found
+  element.remove();
+  return null;
+}

--- a/tools/importer/parsers/image-box.js
+++ b/tools/importer/parsers/image-box.js
@@ -1,0 +1,58 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Parser for image-box (quote banner) → default content
+ *
+ * Source: .jlr-image-box (usually inside a carousel wrapper)
+ * Output: Default content (image + quote paragraph), NOT a block table
+ *
+ * Markdown output example:
+ * ![alt](image-url)
+ *
+ * "Quote text here."
+ *
+ * Source HTML Pattern:
+ * <section class="jlr-section">
+ *   <div class="jlr-image-box-holder">
+ *     <div class="jlr-image-box">
+ *       <picture><img src="..." alt="..." class="jlr-image-box__background"></picture>
+ *       <div class="jlr-image-box__content">
+ *         <div class="jlr-paragraph--size-quote">Quote text</div>
+ *       </div>
+ *     </div>
+ *   </div>
+ * </section>
+ *
+ * Generated: 2026-03-04
+ */
+export default function parse(element, { document }) {
+  const container = document.createElement('div');
+
+  // Extract the background image
+  const img = element.querySelector('.jlr-image-box__background')
+    || element.querySelector('.jlr-image-box img')
+    || element.querySelector('img');
+
+  if (img) {
+    const imgEl = document.createElement('img');
+    imgEl.src = img.getAttribute('src');
+    imgEl.alt = img.getAttribute('alt') || '';
+    container.appendChild(imgEl);
+  }
+
+  // Extract quote text
+  const quote = element.querySelector('.jlr-paragraph--size-quote')
+    || element.querySelector('.jlr-image-box__content .jlr-paragraph');
+
+  if (quote) {
+    const p = document.createElement('p');
+    // Wrap in quotes to match ground truth format
+    const text = quote.textContent.trim();
+    p.textContent = `"${text}"`;
+    container.appendChild(p);
+  }
+
+  // This outputs default content, not a block table
+  element.replaceWith(container);
+}

--- a/tools/importer/parsers/metadata.js
+++ b/tools/importer/parsers/metadata.js
@@ -1,0 +1,44 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Page Metadata block creator
+ *
+ * Extracts <meta> tags from <head> and creates the Metadata block
+ * that appears at the bottom of every EDS page.
+ *
+ * Output:
+ *   | **Metadata** | |
+ *   | title | Page Title |
+ *   | description | Meta description |
+ *   | og:image | https://cdn.example.com/image.jpg |
+ */
+
+/**
+ * Create the page Metadata block from document head.
+ * @param {Document} document
+ * @returns {Element}
+ */
+export function createMetadataBlock(document) {
+  const cells = [];
+
+  // Title
+  const title = document.querySelector('title');
+  if (title && title.textContent.trim()) {
+    cells.push([['title'], [title.textContent.trim()]]);
+  }
+
+  // Description
+  const desc = document.querySelector('meta[name="description"]');
+  if (desc && desc.getAttribute('content')) {
+    cells.push([['description'], [desc.getAttribute('content')]]);
+  }
+
+  // Open Graph image
+  const ogImage = document.querySelector('meta[property="og:image"]');
+  if (ogImage && ogImage.getAttribute('content')) {
+    cells.push([['og:image'], [ogImage.getAttribute('content')]]);
+  }
+
+  return WebImporter.Blocks.createBlock(document, { name: 'Metadata', cells });
+}

--- a/tools/importer/parsers/remove-elements.js
+++ b/tools/importer/parsers/remove-elements.js
@@ -1,0 +1,12 @@
+/* eslint-disable */
+
+/**
+ * Removes non-content elements that should be stripped during import.
+ * Used for: .jlr-in-page-navigation, .jlr-html-box (iframe embeds),
+ * standalone .jlr-tabs navigation sections.
+ *
+ * @param {Element} element  The element to remove
+ */
+export default function parse(element) {
+  element.remove();
+}

--- a/tools/importer/parsers/section-metadata.js
+++ b/tools/importer/parsers/section-metadata.js
@@ -1,0 +1,69 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Section Metadata helpers
+ *
+ * Creates Section Metadata blocks from JLR theme CSS classes.
+ * Theme mapping:
+ *   jlr-section--dark-theme   → Style: dark
+ *   jlr-section--light-theme  → Style: light
+ *   jlr-section--grey-theme   → Style: disclaimer
+ *   jlr-section--white-theme  → (no metadata needed, default)
+ */
+
+const THEME_MAP = {
+  'jlr-section--dark-theme': 'dark',
+  'jlr-section--light-theme': 'light',
+  'jlr-section--grey-theme': 'disclaimer',
+};
+
+/**
+ * Detect the theme class on a section element.
+ * @param {Element} sectionEl
+ * @returns {string|null} The JLR theme class, or null
+ */
+export function getThemeFromSection(sectionEl) {
+  if (!sectionEl) return null;
+  for (const cls of Object.keys(THEME_MAP)) {
+    if (sectionEl.classList && sectionEl.classList.contains(cls)) return cls;
+  }
+  return null;
+}
+
+/**
+ * Get the EDS style value for a theme class.
+ * @param {string} themeClass
+ * @returns {string|null}
+ */
+export function getStyleValue(themeClass) {
+  return THEME_MAP[themeClass] || null;
+}
+
+/**
+ * Create a Section Metadata block element.
+ * @param {Document} document
+ * @param {string} themeClass  One of the THEME_MAP keys
+ * @returns {Element|null}     The block element, or null if white/default theme
+ */
+export function createSectionMetadata(document, themeClass) {
+  const style = THEME_MAP[themeClass];
+  if (!style) return null;
+
+  const cells = [
+    [['Style'], [style]],
+  ];
+  return WebImporter.Blocks.createBlock(document, { name: 'Section Metadata', cells });
+}
+
+/**
+ * Create a Section Metadata block from a section element (auto-detects theme).
+ * @param {Document} document
+ * @param {Element} sectionEl
+ * @returns {Element|null}
+ */
+export function createSectionMetadataFromElement(document, sectionEl) {
+  const theme = getThemeFromSection(sectionEl);
+  if (!theme) return null;
+  return createSectionMetadata(document, theme);
+}

--- a/tools/importer/parsers/tabbed-component.js
+++ b/tools/importer/parsers/tabbed-component.js
@@ -1,0 +1,94 @@
+/* eslint-disable */
+/* global WebImporter */
+
+/**
+ * Parser for tabbed-component → Columns block (image + text)
+ *
+ * Source: .jlr-tabbed-component (usually inside a parent section)
+ * Base Block: Columns
+ *
+ * Only extracts the active/first tab's content (matches ground truth).
+ *
+ * Block Structure (from markdown example):
+ * | **Columns** | |
+ * | --- | --- |
+ * | ![img](url) | ## HEADING Description text |
+ *
+ * Source HTML Pattern:
+ * <section class="jlr-section">
+ *   <div class="jlr-tabbed-component">
+ *     <div>
+ *       <div class="jlr-image-component">
+ *         <img src="..." class="jlr-image">
+ *       </div>
+ *     </div>
+ *     <section class="jlr-tabbed-component__navigation">
+ *       <nav class="jlr-tabs__navigation">
+ *         <button class="jlr-tab-button--active">INTUITIVE</button>
+ *       </nav>
+ *     </section>
+ *     <div class="jlr-tabbed-component__copy-box jlr-copy-box">
+ *       <h2>INTUITIVE</h2>
+ *       <div class="jlr-copy-box__paragraph">Description</div>
+ *     </div>
+ *   </div>
+ * </section>
+ *
+ * Generated: 2026-03-04
+ */
+export default function parse(element, { document }) {
+  const cells = [];
+
+  // Find the tabbed component root
+  const tabbed = element.classList.contains('jlr-tabbed-component')
+    ? element
+    : element.querySelector('.jlr-tabbed-component');
+
+  if (!tabbed) {
+    element.remove();
+    return;
+  }
+
+  // Extract the main image (shared across tabs)
+  const img = tabbed.querySelector('.jlr-image-component img')
+    || tabbed.querySelector('img');
+
+  // Extract the active tab's text content
+  const copyBox = tabbed.querySelector('.jlr-copy-box')
+    || tabbed.querySelector('.jlr-tabbed-component__copy-box');
+
+  const heading = copyBox
+    ? (copyBox.querySelector('.jlr-copy-box__heading') || copyBox.querySelector('h2'))
+    : null;
+
+  const desc = copyBox
+    ? (copyBox.querySelector('.jlr-copy-box__paragraph') || copyBox.querySelector('.jlr-paragraph'))
+    : null;
+
+  // Build image cell
+  const imageCell = [];
+  if (img) {
+    const imgEl = document.createElement('img');
+    imgEl.src = img.getAttribute('src');
+    imgEl.alt = img.getAttribute('alt') || '';
+    imageCell.push(imgEl);
+  }
+
+  // Build text cell
+  const textCell = [];
+  if (heading) {
+    const h2 = document.createElement('h2');
+    h2.textContent = heading.textContent.trim();
+    textCell.push(h2);
+  }
+  if (desc) {
+    textCell.push(desc.textContent.trim());
+  }
+
+  if (imageCell.length > 0 || textCell.length > 0) {
+    cells.push([imageCell, textCell]);
+  }
+
+  const block = WebImporter.Blocks.createBlock(document, { name: 'Columns', cells });
+  element.replaceWith(block);
+}

--- a/tools/importer/transformers/landrover-cleanup.js
+++ b/tools/importer/transformers/landrover-cleanup.js
@@ -62,8 +62,50 @@ export default function transform(hookName, element, payload) {
     ]);
 
     // Remove slide-down chevron button from hero
-    // EXTRACTED: Found in captured DOM <button class="jlr-immersive-hero__slide-down">
     WebImporter.DOMUtils.remove(element, ['.jlr-immersive-hero__slide-down']);
+
+    // Remove breadcrumbs
+    WebImporter.DOMUtils.remove(element, [
+      '.breadcrumbs-container',
+      '.breadcrumbs-seo',
+    ]);
+
+    // Remove in-page navigation (sticky anchor nav)
+    WebImporter.DOMUtils.remove(element, ['.jlr-in-page-navigation']);
+
+    // Remove iframe embeds (configurator / MENA)
+    WebImporter.DOMUtils.remove(element, ['.jlr-html-box', '.jlr-html-elements']);
+
+    // Remove swiper pagination and navigation controls (decorative)
+    WebImporter.DOMUtils.remove(element, [
+      '.swiper-pagination',
+      '.swiper-button-next',
+      '.swiper-button-prev',
+      '.jlr-carousel__loader-box',
+      '.jlr-carousel__hero-pagination',
+      '.jlr-carousel__hero-navigation-prev',
+      '.jlr-carousel__hero-navigation-next',
+      '.jlr-hero-carousel-core__container-end',
+      '.jlr-slider__pagination',
+      '.jlr-slider__navigation-prev',
+      '.jlr-slider__navigation-next',
+    ]);
+
+    // Remove hotspot interactive overlays (non-content)
+    WebImporter.DOMUtils.remove(element, [
+      '.jlr-hotspot',
+      '.jlr-hotspots-container__text',
+    ]);
+
+    // Remove footer
+    WebImporter.DOMUtils.remove(element, [
+      '.jlr-footer',
+      'footer',
+      '.footer-disclaimer',
+    ]);
+
+    // Remove cookie banner
+    WebImporter.DOMUtils.remove(element, ['.jlr-cookie-banner']);
 
     // Enable scrolling if body has overflow hidden
     if (element.style && element.style.overflow === 'hidden') {

--- a/tools/importer/utils/icon-map.js
+++ b/tools/importer/utils/icon-map.js
@@ -1,0 +1,40 @@
+/* eslint-disable */
+
+/**
+ * Maps JLR source icon CSS classes to EDS Floating Quicklinks icon tokens.
+ *
+ * Source:  <i class="ready-to-go-bar__icon jlr-icon icon-ignite-configure">
+ * Output:  :configure:
+ */
+
+const ICON_MAP = {
+  'icon-ignite-configure': 'configure',
+  'icon-ignite-drive': 'steering-wheel',
+  'icon-phone': 'steering-wheel',
+  'icon-map-pin': 'envelope',
+  'icon-thumbnail_view': 'calculator',
+  'icon-request-quote-dollar': 'envelope',
+  'icon-envelope': 'envelope',
+  'icon-calculator': 'calculator',
+  'icon-bookmark': 'envelope',
+};
+
+/**
+ * Determine the EDS icon token from a JLR icon element.
+ * Falls back to positional mapping if no CSS class match.
+ *
+ * @param {Element} iconElement  The <i> element with icon classes
+ * @param {number}  index        Position in the quicklinks bar (0-based)
+ * @returns {string} EDS icon token name (without colons)
+ */
+export function getIconName(iconElement, index) {
+  if (iconElement) {
+    for (const [cssClass, edsName] of Object.entries(ICON_MAP)) {
+      if (iconElement.classList.contains(cssClass)) return edsName;
+    }
+  }
+
+  // Positional fallback: Build / Test Drive / Callback / Find Retailer
+  const positionalMap = ['configure', 'steering-wheel', 'calculator', 'envelope'];
+  return positionalMap[index] || 'link';
+}


### PR DESCRIPTION
Automated migration updates generated by Experience Modernization Agent.

Fixes: #12 

Changed files (18):
- tools/importer/import.js
- tools/importer/page-templates.json
- tools/importer/page-transformers/vehicle-family-overview.js
- tools/importer/page-transformers/vehicle-model-overview.js
- tools/importer/parsers/carousel.js
- tools/importer/parsers/columns.js
- tools/importer/parsers/electrifying-power.js
- tools/importer/parsers/floating-quicklinks.js
- tools/importer/parsers/hero-image-carousel.js
- tools/importer/parsers/hero.js
- tools/importer/parsers/hotspots.js
- tools/importer/parsers/image-box.js
- tools/importer/parsers/metadata.js
- tools/importer/parsers/remove-elements.js
- tools/importer/parsers/section-metadata.js
- tools/importer/parsers/tabbed-component.js
- tools/importer/transformers/landrover-cleanup.js
- tools/importer/utils/icon-map.js

## Test URLs:

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/defender/26my/defender-110/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/defender/26my/defender-110/overview

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/defender/26my/defender-130/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/defender/26my/defender-130/overview

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/defender/26my/defender-90/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/defender/26my/defender-90/overview

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/defender/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/defender/overview

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/discovery/26my/discovery/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/discovery/26my/discovery/overview

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/discovery/26my/discovery-sport/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/discovery/26my/discovery-sport/overview

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/discovery/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/discovery/overview

**index**
- Before: https://main--poc-er--aemdemos.aem.page/en/index
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/index

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/range-rover/25my/range-rover/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/range-rover/25my/range-rover/overview

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/range-rover/25my/range-rover-sport/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/range-rover/25my/range-rover-sport/overview

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/range-rover/26my/range-rover-evoque/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/range-rover/26my/range-rover-evoque/overview

**overview**
- Before: https://main--poc-er--aemdemos.aem.page/en/range-rover/26my/range-rover-velar/overview
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/en/range-rover/26my/range-rover-velar/overview

**footer**
- Before: https://main--poc-er--aemdemos.aem.page/footer
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/footer

**nav**
- Before: https://main--poc-er--aemdemos.aem.page/nav
- After: https://aem-20260304-1124--poc-er--aemdemos.aem.page/nav

